### PR TITLE
Update template with a course name edit

### DIFF
--- a/template/before.sh.erb
+++ b/template/before.sh.erb
@@ -65,4 +65,4 @@ export MY_JUP_BASEURL=/node/${host}/${port}/
 export JOBROOT=$PWD
 
 export CONTAINER_REPO=/n/helmod/apps/centos7/Singularity/OOD_Apps_academic_cluster/Fall_2020
-export COURSE=fasrc_sandbox
+export COURSE=e298dh_test


### PR DESCRIPTION
This PR sets the `COURSE` shell variable to "e298dh_test", i.e. the name of the course that we (FAS) are looking to test on FAS OnDemand.
