### PR TITLE
Add Dockerfile for e298dh_test

### DIFF
--- a/Dockerfiles/e298dh_test/Dockerfile
+++ b/Dockerfiles/e298dh_test/Dockerfile
@@ -1,0 +1,2 @@
+FROM jupyter/scipy-notebook:54462805efcb
+RUN conda install --quiet --yes numpy matplotlib pandas

--- a/Dockerfiles/e298dh_test/Readme.md
+++ b/Dockerfiles/e298dh_test/Readme.md
@@ -1,0 +1,12 @@
+### Dockerfile for the docker image jupyter_e298dh_test at https://hub.docker.com/repository/docker/harvardat/jupyter_e298dh_test.
+
+The Dockerfile is based on the requirements of English 298DH, a course that used FAS/SEAS JupyterHub in Spring 2020.
+
+The requirements included:
+- Python 3 jupyter kernel
+- Packages:
+    - numpy
+    - matplotlib
+    - pandas
+
+To build the docker image, from the same directory as this Dockerfile, run `docker build -t jupyter_e298dh_test .`


### PR DESCRIPTION
@pontiggi, this PR adds a Dockerfile for course e298dh_test, a course we (FAS) are looking to test on FAS OnDemand.

As an aside, you will notice that there is another branch, called `e298dh_test`, on which I have made a change to the before.sh.erb template (commit 42a0c78). Our understanding is that each course is will have its own branch, and the course branches will live in parallel with the master branch, without getting merged in. Correct me if I am wrong.

That said, it is our understanding that this PR, simply adding a Dockerfile and its readme, can get merged into the master branch.