### PR TITLE
Update atg-jupyter-general Dockerfile

### DIFF
--- a/Dockerfiles/atg-jupyter-general/Dockerfile
+++ b/Dockerfiles/atg-jupyter-general/Dockerfile
@@ -1,23 +1,43 @@
 FROM jupyter/minimal-notebook
 
 RUN conda install --quiet --yes \
+    'altair' \
+    'arviz' \
     'bokeh' \
+    'beautifulsoup4' \
     'control' \
+    'dash' \
     'filterpy' \
+    'gensim' \
+    'holoviews' \
+    'ipytest' \
     'IPython' \
     'ipywidgets' \
+    'jupyterlab' \
     'matplotlib' \
+    'mkl-service' \
     'mesa' \
+    'mne' \
     'mpmath' \
+    'networkx' \
+    'nltk' \
     'numba' \
-    'numpy' \
+    'numpy=1.18.5' \
     'openpyxl' \
+    'opencv' \
     'pandas' \
+    'peakutils' \
+    'pillow' \
+    'plotly' \
     'powerlaw' \
     'requests' \
+    'rpy2' \
+    'scikit-image' \
     'scikit-learn' \
-    'scipy' \
+    'scipy=1.4.1' \
     'seaborn' \
+    'spacy' \
+    'statsmodels' \
     'sympy' \
     'thinkx' \
     'xlrd' \
@@ -40,11 +60,16 @@ RUN conda install --quiet --yes \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
     
-RUN export CPATH=$CPATH:/usr/local/cuda-10.0/targets/aarch64-linux/include
-RUN export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/cuda-10.0/targets/aarch64-linux/lib
-    
 RUN pip install --upgrade pip && \
-    pip install --no-cache-dir pycuda stochastic
+    pip install --no-cache-dir gap-stat gym progressbar2 pygam stochastic tensorflow-gpu
+
+# Install facets which does not have a pip or conda package at the moment
+WORKDIR /tmp
+RUN git clone https://github.com/PAIR-code/facets.git && \
+    jupyter nbextension install facets/facets-dist/ --sys-prefix && \
+    rm -rf /tmp/facets && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"
 
 # Import matplotlib the first time to build the font cache.
 ENV XDG_CACHE_HOME="/home/${NB_USER}/.cache/"


### PR DESCRIPTION
This PR updates the Dockerfile for the [atg-jupyter-general docker image](https://hub.docker.com/repository/docker/harvardat/atg-jupyter-general). I have already built and pushed the image to the [docker hub repository](https://hub.docker.com/repository/docker/harvardat/atg-jupyter-general).

The changes in the PR include:
- Including the [cs109a packages](https://github.com/fasrc/fas-ondemand-jupyter-app/blob/cs109a/medium/Dockerfiles/cs109a/Dockerfile) in the [atg-jupyter-general Dockerfile](https://github.com/fasrc/fas-ondemand-jupyter-app/blob/general/small/Dockerfiles/atg-jupyter-general/Dockerfile)
- Including packages requested in [fall 2020 courses so far](https://docs.google.com/spreadsheets/d/1uWiCj56R4uGGYgHjCQ9ubIsiXVAE3AwoABDIeBm4930/edit#gid=315841620)
- Removing the `pycuda` package whose installation throws an error that's not worth the trouble figuring out, for now
- Pinning `numpy` and `scipy` to particular versions so as to satisfy compatibility requirements of `tensorflow-gpu`. Concretely, the latest tensorflow-gpu package, i.e. `tensorflow-gpu=2.3.0`, requires `numpy<1.19.0,>=1.16.0` and `scipy==1.4.1`. (In case the "gpu" part of the package name is confusing, `tensorflow-gpu` can run on either cpu or gpu, and the way to import is `import tensorflow`. So, we're fine.)

RATIONALE FOR INCLUDING EVERYTHING IN THE GENERAL IMAGE

a). With all fall 2020 packages, including cs109a, included in the `atg-jupyter-general` image, we can use said image for all courses. I reckon this means that **we wouldn't need to create separate apps** for the different courses, as long as the image is the same and compute power is the same. So, under the "Interactive Apps" dropdown, there would be only 2 items for Jupyter Notebooks. Namely:
  - "Jupyter Notebook - General": For all courses, except cs109a. The image behind the scenes will be `atg-jupyter-general` and the compute requirements will be [2 units of memory per node & 1 cpu core](https://github.com/fasrc/fas-ondemand-jupyter-app/blob/cs109a/medium/form.yml).
  - "Jupyter Notebook - CS109a": For cs109a. The image behind the scenes will still be `atg-jupyter-general`, but the compute requirements will be [4 units of memory per node, 2 cpu cores](https://github.com/fasrc/fas-ondemand-jupyter-app/blob/general/small/form.yml)

b). **Keeps number of docker images at a minimum**. So, we create a different docker image only if a class's packages present unresolvable conflicts with the packages in the `atg-jupyter-general` image. We can then name the special image something like `atg-jupyter-classcode`. E.g. for a random class es978, it would be `atg-jupyter-es978`.

c). **Keeps number of git branches in this repo at a minimum**.

WORKFLOW

So, the workflow can be, with each new FAS OnDemand request, we expand the atg-jupyter-general image and redeploy to the `Jupyter Notebook - General" app. We only create a different image if there are unresolvable conflicts with the packages in the atg-jupyter-general image.

@pontiggi , @arthurian , @dodget , does this sound alright?

