### PR TITLE
Fix atg-jupyter-general

### DIFF
--- a/Dockerfiles/atg-jupyter-general/Dockerfile
+++ b/Dockerfiles/atg-jupyter-general/Dockerfile
@@ -1,5 +1,7 @@
 FROM jupyter/minimal-notebook
 
+RUN apt-get install libgl1-mesa-glx
+
 RUN conda install --quiet --yes \
     'altair' \
     'arviz' \

--- a/Dockerfiles/atg-jupyter-general/Dockerfile
+++ b/Dockerfiles/atg-jupyter-general/Dockerfile
@@ -77,6 +77,9 @@ ENV XDG_CACHE_HOME="/home/${NB_USER}/.cache/"
 RUN MPLBACKEND=Agg python -c "import matplotlib.pyplot" && \
     fix-permissions "/home/${NB_USER}"
 
+# Set cache directory for numba so that the package "mne" can work
+ENV NUMBA_CACHE_DIR="/home/${NB_USER}/.cache/"
+
 USER $NB_UID
 
 WORKDIR $HOME

--- a/Dockerfiles/atg-jupyter-general/Dockerfile
+++ b/Dockerfiles/atg-jupyter-general/Dockerfile
@@ -1,6 +1,6 @@
 FROM jupyter/minimal-notebook
 
-RUN apt-get install libgl1-mesa-glx
+RUN sudo apt-get install libgl1-mesa-glx
 
 RUN conda install --quiet --yes \
     'altair' \

--- a/Dockerfiles/atg-jupyter-general/Dockerfile
+++ b/Dockerfiles/atg-jupyter-general/Dockerfile
@@ -1,6 +1,9 @@
 FROM jupyter/minimal-notebook
 
-RUN sudo apt-get install libgl1-mesa-glx
+USER root
+
+RUN apt-get -y update
+RUN apt-get -y install libgl1-mesa-glx
 
 RUN conda install --quiet --yes \
     'altair' \

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -30,6 +30,18 @@ export container_image=$container_folder/<%= context.jupyter_version %>
 
 # Launch the Jupyter Notebook Server
 
+JUPYTER_TMPDIR=${TMPDIR:-/tmp}/$(id -un)-jupyter/
+## for conda
+export SINGULARITYENV_CONDA_PKGS_DIRS=${HOME}/.conda/pkgs
+## for pip
+export SINGULARITYENV_XDG_CACHE_HOME=${JUPYTER_TMPDIR}/xdg_cache_home
+## job specific tmp in case there are conflicts with different users running on the same node
+WORKDIR=/scratch/${USER}/${SLURM_JOB_ID}
+mkdir -m 700 -p ${WORKDIR}/tmp
+
+## for specific package mne
+export SINGULARITYENV_NUMBA_CACHE_DIR=$HOME/.cache
+
 # enable this only if needed for debug purpose. note that the password will appear in the output 
 # set -x
 
@@ -41,6 +53,8 @@ export SING_GPU="--nv"
 
 ## bind some extra stuff to be able to talk to slurm from within the container
 export SING_BINDS=" -B /etc/nsswitch.conf -B /etc/sssd/ -B /var/lib/sss -B /etc/slurm -B /slurm -B /var/run/munge  -B `which sbatch ` -B `which srun ` -B `which sacct ` -B `which scontrol ` -B `which salloc `  -B /usr/lib64/slurm/ "
+## job specific tmp dir
+export SING_BINDS=" $SING_BINDS -B ${WORKDIR}/tmp:/tmp " 
 
 cat > $JOBROOT/jupyter.script.sh <<EOF1
 #!/bin/bash


### PR DESCRIPTION
This PR adds the following:

- Installation of `libgl1-mesa-glx`, a system dependency needed so that the package `opencv` can `import` successfully. Without it, you get the error message below:
```
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-4-28b918b4ed54> in <module>
      4 import scipy
      5 import matplotlib
----> 6 import cv2
      7 import sklearn
      8 import skimage

ImportError: libGL.so.1: cannot open shared object file: No such file or directory
```
- Specifying, as an environment variable, the cache directory for the package `numba`. `numba` is a dependency of the package `mne`, which is one of the packages requested by ES 157. So, `numba` has to be working well in order for `mne` to `import` successfully. As such, `numba` requires the env variable `NUMBA_CACHE_DIR` to be set. Otherwise the error below is thrown:
```
/opt/conda/lib/python3.8/site-packages/numba/core/caching.py in __init__(self, py_func)
    345                 break
    346         else:
--> 347             raise RuntimeError("cannot cache function %r: no locator available "
    348                                "for file %r" % (qualname, source_path))
    349         self._locator = locator

RuntimeError: cannot cache function 'bincount': no locator available for file '/opt/conda/lib/python3.8/site-packages/mne/fixes.py'
```

The updated docker image, with the changes above, can be gotten by doing `docker pull harvardat/atg-jupyter-general:5ad6b1f`.
