### PR TITLE
Add extra conda channels to the cs109a/medium dockerfile

### DIFF
--- a/Dockerfiles/atg-jupyter-general/Dockerfile
+++ b/Dockerfiles/atg-jupyter-general/Dockerfile
@@ -68,6 +68,11 @@ RUN conda install --quiet --yes \
 RUN pip install --upgrade pip && \
     pip install --no-cache-dir gap-stat gym progressbar2 pygam stochastic tensorflow-gpu
 
+# Add extra conda channels
+RUN conda config --append channels conda-forge
+RUN conda config --append channels anaconda-fusion
+RUN conda config --append channels jmcmurray
+
 # Install facets which does not have a pip or conda package at the moment
 WORKDIR /tmp
 RUN git clone https://github.com/PAIR-code/facets.git && \


### PR DESCRIPTION
This PR simply adds conda channels requested by cs109a. The updated image is now `harvardat/atg-jupyter-general:0c18112`. Download it by doing `docker pull harvardat/atg-jupyter-general:0c18112`.

Note: I have also updated the image `harvardat/cs109a` (https://hub.docker.com/repository/docker/harvardat/cs109a), even though we are using the `atg-jupyter-general` (https://hub.docker.com/repository/docker/harvardat/atg-jupyter-general) image for all classes, including cs109a.