### PR TITLE
Add keras to the atg-jupyter-general dockerfile

### DIFF
--- a/Dockerfiles/atg-jupyter-general/Dockerfile
+++ b/Dockerfiles/atg-jupyter-general/Dockerfile
@@ -66,7 +66,7 @@ RUN conda install --quiet --yes \
     fix-permissions "/home/${NB_USER}"
     
 RUN pip install --upgrade pip && \
-    pip install --no-cache-dir gap-stat gym progressbar2 pygam stochastic tensorflow-gpu
+    pip install --no-cache-dir gap-stat gym progressbar2 pygam stochastic tensorflow-gpu keras
 
 # Add extra conda channels
 RUN conda config --append channels conda-forge


### PR DESCRIPTION
This PR simply adds the package `keras` to the `general/small` dockerfile. The corresponding docker image has been rebuilt accordingly, i.e. `harvardat/atg-jupyter-general:a6ce412`.