### PR TITLE
Add extra packages to the cs109 Dockerfile

### DIFF
--- a/Dockerfiles/atg-jupyter-general/Dockerfile
+++ b/Dockerfiles/atg-jupyter-general/Dockerfile
@@ -1,5 +1,4 @@
-# Use base image with the requested Python version 3.7
-FROM jupyter/minimal-notebook:29a003bb3030
+FROM jupyter/minimal-notebook
 
 USER root
 
@@ -11,7 +10,7 @@ RUN apt-get -y install pkg-config jags
 
 # Install python packages using pip
 RUN pip install --upgrade pip
-RUN pip install --no-cache-dir tensorflow-gpu==2.0.0
+RUN pip install --no-cache-dir tensorflow-gpu
 RUN pip install --no-cache-dir altair arviz bokeh beautifulsoup4 control
 RUN pip install --no-cache-dir dash filterpy gensim holoviews ipytest
 RUN pip install --no-cache-dir IPython ipywidgets jupyterlab matplotlib
@@ -21,6 +20,7 @@ RUN pip install --no-cache-dir pillow plotly powerlaw pymc3 requests
 RUN pip install --no-cache-dir scikit-image scikit-learn scipy seaborn
 RUN pip install --no-cache-dir spacy statsmodels sympy thinkx xlrd xlsxwriter
 RUN pip install --no-cache-dir gap-stat gym progressbar2 pygam stochastic keras opencv-python pyjags csaps
+RUN pip install --no-cache-dir certifi depfinder gdown imageio mamba theano urllib3
 
 # Update conda
 RUN conda update --quiet --yes conda


### PR DESCRIPTION
This PR adds some extra packages that cs109b has requested. Tensorflow has also been upgraded to the latest version. The updated docker image is `harvardat/cs109:1e263a8` (https://hub.docker.com/layers/135292007/harvardat/cs109/1e263a8/images/sha256-7a0680bd6b0c7443e50645c8948ff5893bea1b4da35d306de937a43ae2acca27?context=explore).
