### PR TITLE
Install pymc3 via conda

### DIFF
--- a/Dockerfiles/atg-jupyter-general/Dockerfile
+++ b/Dockerfiles/atg-jupyter-general/Dockerfile
@@ -16,7 +16,7 @@ RUN pip install --no-cache-dir dash filterpy gensim holoviews ipytest
 RUN pip install --no-cache-dir IPython ipywidgets jupyterlab matplotlib
 RUN pip install --no-cache-dir mesa mne mpmath networkx nltk
 RUN pip install --no-cache-dir numba numpy openpyxl pandas peakutils
-RUN pip install --no-cache-dir pillow plotly powerlaw pymc3 requests
+RUN pip install --no-cache-dir pillow plotly powerlaw requests
 RUN pip install --no-cache-dir scikit-image scikit-learn scipy seaborn
 RUN pip install --no-cache-dir spacy statsmodels sympy thinkx xlrd xlsxwriter
 RUN pip install --no-cache-dir gap-stat gym progressbar2 pygam stochastic keras opencv-python pyjags csaps
@@ -26,7 +26,7 @@ RUN pip install --no-cache-dir certifi depfinder gdown imageio mamba theano urll
 RUN conda update --quiet --yes conda
 
 # Install python packages using conda
-RUN conda install --quiet --yes -c conda-forge mkl-service rpy2
+RUN conda install --quiet --yes -c conda-forge mkl-service rpy2 pymc3
 
 # Install R packages
 RUN conda install --quiet --yes 'r-aplpack' 'r-cluster' 'r-codetools' 'r-dbscan' 'r-factoextra' \


### PR DESCRIPTION
Problem:

![image](https://user-images.githubusercontent.com/18121426/107055838-c0cf1a00-67e2-11eb-9fb3-ad0297370b9a.png)

This PR resolves the error above. Basically, the issue is a missing dependency for the pymc3 package. Installing the package using conda resolves the issue - conda resolves the dependencies better than pip in this case.

Updated docker image: harvardat/cs109:730ddcc (https://hub.docker.com/layers/136388743/harvardat/cs109/730ddcc/images/sha256-19bf176ed7a2464cfdfabfeb6c7dd32fc537dad0f297045724f83e96a49aaf78?context=explore)