### PR TITLE
Update cs109 OnDemand

### DIFF
--- a/Dockerfiles/atg-jupyter-general/Dockerfile
+++ b/Dockerfiles/atg-jupyter-general/Dockerfile
@@ -11,23 +11,27 @@ RUN apt-get -y install pkg-config jags
 # Install python packages using pip
 RUN pip install --upgrade pip
 RUN pip install --no-cache-dir tensorflow-gpu tensorflow-addons tensorflow-datasets tf-keras-vis
-RUN pip install --no-cache-dir altair arviz bokeh beautifulsoup4 control
-RUN pip install --no-cache-dir dash filterpy gensim holoviews ipytest
-RUN pip install --no-cache-dir IPython ipywidgets jupyterlab matplotlib
-RUN pip install --no-cache-dir mesa mne mpmath networkx nltk
-RUN pip install --no-cache-dir numba numpy openpyxl pandas peakutils
-RUN pip install --no-cache-dir pillow plotly powerlaw requests
-RUN pip install --no-cache-dir scikit-image scikit-learn scipy seaborn
-RUN pip install --no-cache-dir spacy statsmodels sympy thinkx xlrd xlsxwriter
-RUN pip install --no-cache-dir gap-stat gym progressbar2 pygam stochastic keras opencv-python pyjags csaps
-RUN pip install --no-cache-dir certifi depfinder gdown imageio mamba theano urllib3
-RUN pip install --no-cache-dir gridworld helpers iacs-cli
+RUN pip install --no-cache-dir pyjags csaps gridworld helpers iacs-cli gap-stat
 
 # Update conda
 RUN conda update --quiet --yes conda
 
+# Add the conda-forge conda channel
+RUN conda config --append channels conda-forge
+
 # Install python packages using conda
-RUN conda install --quiet --yes -c conda-forge mkl-service rpy2 pymc3
+RUN conda install --quiet --yes mkl-service rpy2 pymc3
+RUN conda install --quiet --yes gym progressbar2 pygam
+RUN conda install --quiet --yes altair arviz bokeh beautifulsoup4 control
+RUN conda install --quiet --yes dash filterpy gensim holoviews ipytest
+RUN conda install --quiet --yes IPython ipywidgets jupyterlab matplotlib
+RUN conda install --quiet --yes mesa mne mpmath networkx nltk
+RUN conda install --quiet --yes numba numpy openpyxl pandas peakutils
+RUN conda install --quiet --yes pillow plotly powerlaw requests
+RUN conda install --quiet --yes scikit-image scikit-learn scipy seaborn
+RUN conda install --quiet --yes spacy statsmodels sympy thinkx xlrd xlsxwriter
+RUN conda install --quiet --yes stochastic keras opencv
+RUN conda install --quiet --yes certifi depfinder gdown imageio mamba theano urllib3
 
 # Install R packages
 RUN conda install --quiet --yes 'r-aplpack' 'r-cluster' 'r-codetools' 'r-dbscan' 'r-factoextra' \
@@ -36,7 +40,6 @@ RUN conda install --quiet --yes 'r-aplpack' 'r-cluster' 'r-codetools' 'r-dbscan'
 RUN conda clean --al -f -y
 
 # Add extra conda channels
-RUN conda config --append channels conda-forge
 RUN conda config --append channels anaconda-fusion
 RUN conda config --append channels jmcmurray
 

--- a/Dockerfiles/atg-jupyter-general/Dockerfile
+++ b/Dockerfiles/atg-jupyter-general/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get -y install pkg-config jags
 
 # Install python packages using pip
 RUN pip install --upgrade pip
-RUN pip install --no-cache-dir tensorflow-gpu
+RUN pip install --no-cache-dir tensorflow-gpu tensorflow-addons tensorflow-datasets tf-keras-vis
 RUN pip install --no-cache-dir altair arviz bokeh beautifulsoup4 control
 RUN pip install --no-cache-dir dash filterpy gensim holoviews ipytest
 RUN pip install --no-cache-dir IPython ipywidgets jupyterlab matplotlib
@@ -21,6 +21,7 @@ RUN pip install --no-cache-dir scikit-image scikit-learn scipy seaborn
 RUN pip install --no-cache-dir spacy statsmodels sympy thinkx xlrd xlsxwriter
 RUN pip install --no-cache-dir gap-stat gym progressbar2 pygam stochastic keras opencv-python pyjags csaps
 RUN pip install --no-cache-dir certifi depfinder gdown imageio mamba theano urllib3
+RUN pip install --no-cache-dir gridworld helpers iacs-cli
 
 # Update conda
 RUN conda update --quiet --yes conda

--- a/form.yml
+++ b/form.yml
@@ -15,7 +15,7 @@ attributes:
   custom_memory_per_node: 32
   custom_num_cores: 8
   custom_num_gpus: 0
-  jupyter_version: "harvardat_cs109_730ddcc.sif"
+  jupyter_version: "harvardat_cs109_a52c960.sif"
   custom_reservation: null
   envscript: null
   bc_account:

--- a/form.yml
+++ b/form.yml
@@ -12,8 +12,8 @@ attributes:
   custom_email_address:
     label: email address for status notification
     widget: text_field
-  custom_memory_per_node: 4
-  custom_num_cores: 2
+  custom_memory_per_node: 32
+  custom_num_cores: 8
   custom_num_gpus: 0
   jupyter_version: "harvardat_cs109_730ddcc.sif"
   custom_reservation: null

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -84,4 +84,5 @@ jupyter notebook \
 
 EOF3
 
+export SINGULARITYENV_OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
 singularity exec $SING_GPU $SING_BINDS $container_image $JOBROOT/jupyter.script.sh


### PR DESCRIPTION
This PR updates the cs109 OnDemand setup as follows:
- Increase the number of CPU cores and RAM available to each user. CS109b has reported that some tasks, e.g. clustering, are taking an upwards of 1.5 hours to run on FAS OnDemand as compared to 15 minutes on local machines. Looks like the t2.medium-equivalent capacity of 2 vCPUs and 4GB RAM is insufficient. Accordingly, this PR bumps that up to a t2.2xlarge-equivalent, i.e. 8 vCPUs and 32GB RAM. I suppose a t2.xlarge-equivalent, i.e. 4 vCPUs and 16GB RAM, would also be fine. But let's do the t2.2xlarge-equivalent to be safe, if we can afford it
- Addition of some 6 extra python packages that have been requested
- Switching back to using conda to install most of the packages in the Dockerfile, as opposed to pip. Upon attempting to install the 6 additional packages mentioned above, the installation errored out due to a couple of dependency conflicts. And the error message said `pip's dependency resolver does not currently take into account all the packages that are installed`. Switching to `conda` resolved the issue. (I had opted to use pip earlier because it is marginally faster. But conda can be sufficiently fast too insofar one remembers to update conda prior to doing the conda installs.)

The updated docker image is harvardat/cs109:a52c960. (See https://hub.docker.com/layers/137810675/harvardat/cs109/a52c960/images/sha256-5c8a3139b37a20a56a98fa60b7605bbcc28779d001b4c87e069788db0abd6a44?context=explore)